### PR TITLE
WIP: Update pchain network engine

### DIFF
--- a/src/behaviour.rs
+++ b/src/behaviour.rs
@@ -54,7 +54,7 @@ impl PeerBehaviour {
 
         // Configure Gossipsub - subscribe to the topic of its own the base64-encoded public address
         let mut gossip = Self::gossipsub_config(local_key, heartbeat_secs);
-        gossip.subscribe(&Topic::Mailbox(id).into()).unwrap();
+        gossip.subscribe(&Topic::HotStuffRsSend(id).into()).unwrap();
 
         // Configure Ping
         let ping = ping::Behaviour::default();
@@ -142,7 +142,7 @@ impl PeerBehaviour {
         address: PublicAddress,
         msg: Message,
     ) -> Result<MessageId, PublishError> {
-        let topic = Topic::Mailbox(address).hash();
+        let topic = Topic::HotStuffRsSend(address).hash();
         let content: Vec<u8> = msg.into();
         self.gossip.publish(topic, content)
     }
@@ -274,7 +274,7 @@ mod test {
     fn test_subscribe_topics() {
         let mut peer1 = create_new_peer();
         
-        let self_topic_hash = Topic::Mailbox(peer1.public_address).hash();
+        let self_topic_hash = Topic::HotStuffRsSend(peer1.public_address).hash();
         
         let self_topic_message = gossipsub::Message {
             source: None,
@@ -289,16 +289,16 @@ mod test {
             source: None,
             data: vec![],
             sequence_number: None,
-            topic: Topic::Consensus.hash(),
+            topic: Topic::HotStuffRsBroadcast.hash(),
         };
-        let _ = peer1.behaviour.subscribe(vec![Topic::Consensus]);
+        let _ = peer1.behaviour.subscribe(vec![Topic::HotStuffRsBroadcast]);
         
         // create Message with unsubscribed topic
         let unsubscribed_msg = gossipsub::Message {
             source: None,
             data: vec![],
             sequence_number: None,
-            topic: Topic::DroppedTx.hash(),
+            topic: Topic::DroppedTxns.hash(),
         };
         
         let subscribed_topics: Vec<&MessageTopicHash> = peer1.behaviour.gossip.topics().collect();

--- a/src/behaviour.rs
+++ b/src/behaviour.rs
@@ -136,19 +136,8 @@ impl PeerBehaviour {
         Ok(())
     }
 
-    /// Send [Message] to peer with the given address
-    pub fn send_to(
-        &mut self,
-        address: PublicAddress,
-        msg: Message,
-    ) -> Result<MessageId, PublishError> {
-        let topic = Topic::HotStuffRsSend(address).hash();
-        let content: Vec<u8> = msg.into();
-        self.gossip.publish(topic, content)
-    }
-
-    /// Broadcast [Message] with a specific topic
-    pub fn broadcast(
+    /// Publish [Message] to peers subscribed to the specific [Topic]
+    pub fn publish(
         &mut self,
         topic: IdentTopic,
         msg: Message,

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,7 +44,7 @@ pub struct Config {
     pub port: u16,
 
     /// bootstrap nodes for initial connection
-    pub boot_nodes: Vec<Peer>,
+    pub boot_nodes: Vec<PeerInfo>,
 
     /// buffer size of commands initiated from caller
     pub send_command_buffer_size: usize,
@@ -120,7 +120,7 @@ impl Config {
     }
 
     /// Set the bootstrap nodes for initial connection.
-    pub fn set_boot_nodes(mut self, boot_nodes: Vec<Peer>) -> Self {
+    pub fn set_boot_nodes(mut self, boot_nodes: Vec<PeerInfo>) -> Self {
         self.boot_nodes = boot_nodes;
         self
     }
@@ -132,10 +132,10 @@ impl Config {
     }
 }
 
-/// [Peer] consists of required information to identify an entity in the network, such as
+/// [PeerInfo] consists of required information to identify an entity in the network, such as
 /// PeerId, IPv4 Address and port number.
 #[derive(Clone)]
-pub struct Peer {
+pub struct PeerInfo {
     /// Peer ID in the P2P network
     pub peer_id: PeerId,
 
@@ -146,8 +146,8 @@ pub struct Peer {
     pub port: u16,
 }
 
-impl Peer {
-    /// Instantiation of [Peer]. It is used in bootstrap nodes in [crate::configuration::Config].
+impl PeerInfo {
+    /// Instantiation of [PeerInfo]. It is used in bootstrap nodes in [crate::configuration::Config].
     ///
     /// ## Panics
     /// Panics if address is not a valid Ed25519 public key.
@@ -270,7 +270,7 @@ mod tests {
         let boot_node_ip_address = Ipv4Addr::new(127, 0, 0, 1);
         let boot_node_port: u16 = 1;
 
-        let boot_node = Peer::new(
+        let boot_node = PeerInfo::new(
             boot_node_public_address,
             boot_node_ip_address,
             boot_node_port,
@@ -298,7 +298,7 @@ mod tests {
         let port: u16 = 1;
 
         //create new instance of Peer Info
-        let peer_info = Peer::new(test_public_address, ip_address, port);
+        let peer_info = PeerInfo::new(test_public_address, ip_address, port);
 
         //test new instance of Peer Info
         assert_eq!(&peer_info.ip_address.to_string(), "127.0.0.1");

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -132,7 +132,7 @@ pub(crate) async fn start(
                             message_gates
                                 .message_in(&Topic::HotStuffRsSend(local_public_address).hash(), envelope)
                                 .await;
-                        } else if let Err(e) = swarm.behaviour_mut().broadcast(topic.into(), message) {
+                        } else if let Err(e) = swarm.behaviour_mut().publish(topic.into(), message) {
                             log::debug!("{:?}", e);
                         }
                     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -45,7 +45,7 @@ use crate::{
     message_gate::MessageGateChain,
     messages::{Envelope, Topic},
     network_handle::SendCommand,
-    NetworkHandle,
+    Peer,
 };
 
 /// [start] p2p networking peer and return the handle [NetworkHandle] of this process.
@@ -53,7 +53,7 @@ pub(crate) async fn start(
     config: Config,
     subscribe_topics: Vec<Topic>,
     message_gates: MessageGateChain,
-) -> Result<NetworkHandle, Box<dyn Error>> {
+) -> Result<Peer, Box<dyn Error>> {
     let local_public_address: PublicAddress =
         conversions::PublicAddress::try_from(config.keypair.public())
             .expect("Invalid PublicKey from configuration")
@@ -189,7 +189,7 @@ pub(crate) async fn start(
         }
     });
 
-    Ok(NetworkHandle {sender})
+    Ok(Peer {sender})
 }
 
 async fn build_transport(

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -97,7 +97,7 @@ pub(crate) async fn start(
     let mut discover_tick =
         tokio::time::interval(Duration::from_secs(config.peer_discovery_interval));
 
-    let _network_thread_handle = tokio::task::spawn(async move {
+    let network_thread_handle = tokio::task::spawn(async move {
         loop {
             // 4.1 Wait for the following events:
             let (send_command, event) = tokio::select! {
@@ -189,7 +189,10 @@ pub(crate) async fn start(
         }
     });
 
-    Ok(Peer {sender})
+    Ok(Peer {
+        engine: network_thread_handle,
+        to_engine: sender
+    })
 }
 
 async fn build_transport(

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -123,14 +123,14 @@ pub(crate) async fn start(
                 match engine_command {
                     EngineCommand::Publish(topic, message) => {
                         log::info!("Publish (Topic: {:?})", topic);
-                        if topic == Topic::Mailbox(local_public_address) {
+                        if topic == Topic::HotStuffRsSend(local_public_address) {
                             // send to myself
                             let envelope = Envelope {
                                 origin: local_public_address,
                                 message: message.into(),
                             };
                             message_gates
-                                .message_in(&Topic::Mailbox(local_public_address).hash(), envelope)
+                                .message_in(&Topic::HotStuffRsSend(local_public_address).hash(), envelope)
                                 .await;
                         } else if let Err(e) = swarm.behaviour_mut().broadcast(topic.into(), message) {
                             log::debug!("{:?}", e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,10 @@
 //! // ...
 //!
 //! // 3. Start P2P network.
-//! let network = pchain_network::NetworkHandle::start(network_config, subscribe_topics, message_gate_chain).await;
+//! let network = pchain_network::Peer::start(network_config, subscribe_topics, message_gate_chain).await;
 //!
 //! // 4. Send out messages.
-//! network.broadcast_mempool_tx_msg(txn);
+//! network.broadcast_mempool_msg(txn);
 
 pub mod config;
 pub use config::Config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub mod messages;
 pub mod message_gate;
 
 pub mod network_handle;
-pub use network_handle::NetworkHandle;
+pub use network_handle::Peer;
 
 pub(crate) mod behaviour;
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -25,7 +25,7 @@ use pchain_types::{
 pub type MessageTopicHash = libp2p::gossipsub::TopicHash;
 
 /// [Topic] defines the topics available for subscribing.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Topic {
     Consensus,
     Mempool,

--- a/src/network_handle.rs
+++ b/src/network_handle.rs
@@ -39,30 +39,30 @@ impl Peer {
 
     }
 
-    pub fn broadcast_mempool_tx_msg(&self, content: &TransactionV1) {
+    pub fn broadcast_mempool_msg(&self, content: &TransactionV1) {
         let _ = self.to_engine.try_send(EngineCommand::Publish(
             Topic::Mempool,
             Message::Mempool(content.clone()),
         ));
     }
 
-    pub fn broadcast_dropped_tx_msg(&self, content: DroppedTxMessage) {
+    pub fn broadcast_dropped_txn_msg(&self, content: DroppedTxMessage) {
         let _ = self.to_engine.try_send(EngineCommand::Publish(
-            Topic::DroppedTx,
+            Topic::DroppedTxns,
             Message::DroppedTx(content),
         ));
     }
 
-    pub fn broadcast_consensus_msg(&self, content: hotstuff_rs::messages::Message) {
+    pub fn broadcast_hotstuff_rs_msg(&self, content: hotstuff_rs::messages::Message) {
         let _ = self.to_engine.try_send(EngineCommand::Publish(
-            Topic::Consensus,
+            Topic::HotStuffRsBroadcast,
             Message::Consensus(content),
         ));
     }
 
-    pub fn send_to(&self, address: PublicAddress, content: hotstuff_rs::messages::Message) {
+    pub fn send_hotstuff_rs_msg(&self, address: PublicAddress, content: hotstuff_rs::messages::Message) {
         let _ = self.to_engine.try_send(EngineCommand::Publish(
-            Topic::Mailbox(address),
+            Topic::HotStuffRsSend(address),
             Message::Consensus(content)
         ));
     }

--- a/src/network_handle.rs
+++ b/src/network_handle.rs
@@ -24,7 +24,7 @@ pub struct Peer {
     /// the p2p network (see[crate::engine])
     pub(crate) engine: JoinHandle<()>,
     /// mpsc sender for delivering message to p2p network
-    pub(crate) to_engine: tokio::sync::mpsc::Sender<SendCommand>,
+    pub(crate) to_engine: tokio::sync::mpsc::Sender<EngineCommand>,
 }
 
 impl Peer {
@@ -40,21 +40,21 @@ impl Peer {
     }
 
     pub fn broadcast_mempool_tx_msg(&self, content: &TransactionV1) {
-        let _ = self.to_engine.try_send(SendCommand::Broadcast(
+        let _ = self.to_engine.try_send(EngineCommand::Broadcast(
             Topic::Mempool,
             Message::Mempool(content.clone()),
         ));
     }
 
     pub fn broadcast_dropped_tx_msg(&self, content: DroppedTxMessage) {
-        let _ = self.to_engine.try_send(SendCommand::Broadcast(
+        let _ = self.to_engine.try_send(EngineCommand::Broadcast(
             Topic::DroppedTx,
             Message::DroppedTx(content),
         ));
     }
 
     pub fn broadcast_consensus_msg(&self, content: hotstuff_rs::messages::Message) {
-        let _ = self.to_engine.try_send(SendCommand::Broadcast(
+        let _ = self.to_engine.try_send(EngineCommand::Broadcast(
             Topic::Consensus,
             Message::Consensus(content),
         ));
@@ -63,13 +63,13 @@ impl Peer {
     pub fn send_to(&self, address: PublicAddress, content: hotstuff_rs::messages::Message) {
         let _ = self
             .to_engine
-            .try_send(SendCommand::SendTo(address, Message::Consensus(content)));
+            .try_send(EngineCommand::SendTo(address, Message::Consensus(content)));
     }
 }
 
-/// A command to send a message either to a specific peer ([SendTo](SendCommand::SendTo)), or to all subscribers
-/// of a network topic ([Broadcast](SendTo::Broadcast)).
-pub enum SendCommand {
+/// A command to send a message either to a specific peer ([SendTo](EngineCommand::SendTo)), or to all subscribers
+/// of a network topic ([Broadcast](EngineCommand::Broadcast)).
+pub enum EngineCommand {
     /// send to a specific peer
     SendTo(PublicAddress, Message),
 

--- a/src/network_handle.rs
+++ b/src/network_handle.rs
@@ -6,8 +6,8 @@
 //! This is the entry point to the pchain_network library. It starts a ParallelChain Network peer
 //! and keeps the peer alive -- the peer stops working when the thread is dropped.
 //!
-//! To send a message in the P2P network, call `.broadcast_mempool_tx_msg()`, `broadcast_dropped_tx_msg`,
-//! `broadcast_consensus_msg` or `.send_to()` directly.
+//! To send a message in the P2P network, call `.broadcast_mempool_msg()`, `broadcast_dropped_txn_msg`,
+//! `broadcast_hotstuff_rs_msg` or `.send_hotstuff_rs_msg()` directly.
 
 use crate::Config;
 use crate::engine;

--- a/src/network_handle.rs
+++ b/src/network_handle.rs
@@ -15,16 +15,16 @@ use crate::message_gate::MessageGateChain;
 use crate::messages::{DroppedTxMessage, Message, Topic};
 use pchain_types::{blockchain::TransactionV1, cryptography::PublicAddress};
 
-/// [NetworkHandle] provides inter-process messaging between application and the p2p
+/// [Peer] provides inter-process messaging between application and the p2p
 /// network. It started the main thread for the p2p network and handles for the [tokio::task]
 /// by calling [crate::engine::start].
 #[derive(Clone)]
-pub struct NetworkHandle {
+pub struct Peer {
     /// mpsc sender for delivering message to p2p network
     pub(crate) sender: tokio::sync::mpsc::Sender<SendCommand>,
 }
 
-impl NetworkHandle {
+impl Peer {
     pub async fn start(
         config: Config,
         subscribe_topics: Vec<Topic>,

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -9,7 +9,7 @@ use pchain_network::{
     config::{Config, PeerInfo},
     message_gate::{MessageGate, MessageGateChain},
     messages::{Topic, Envelope, Message},
-    NetworkHandle,
+    Peer,
 };
 use pchain_types::{blockchain::TransactionV1, cryptography::PublicAddress};
 
@@ -290,7 +290,7 @@ pub async fn node(
     boot_nodes: Vec<PeerInfo>,
     gate_topic: Option<Topic>,
     subscribe_topics: Vec<Topic>,
-) -> (PublicAddress, NetworkHandle, MessageCounts) {
+) -> (PublicAddress, Peer, MessageCounts) {
     let keypair: Keypair = Keypair::generate_ed25519();
     let address = public_address(&keypair.public());
     let config = Config::with_keypair(
@@ -311,7 +311,7 @@ pub async fn node(
     };
     let message_chain = MessageGateChain::new().append(gate.clone());
 
-    let node = pchain_network::NetworkHandle::start(config, subscribe_topics, message_chain)
+    let node = pchain_network::Peer::start(config, subscribe_topics, message_chain)
         .await;
 
     (address, node, gate)

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -57,7 +57,7 @@ async fn test_broadcast() {
     loop {
         tokio::select! {
             _ = sending_tick.tick() => {
-                node_1.broadcast_mempool_tx_msg(&base_tx(address_1));
+                node_1.broadcast_mempool_msg(&base_tx(address_1));
                 if sending_limit == 0 { break }
                 sending_limit -= 1;
             }
@@ -97,7 +97,7 @@ async fn test_send_to() {
     loop {
         tokio::select! {
             _ = sending_tick.tick() => {
-                node_1.send_to(address_2, message.clone());
+                node_1.send_hotstuff_rs_msg(address_2, message.clone());
                 if sending_limit == 0 { break }
                 sending_limit -= 1;
             }
@@ -145,7 +145,7 @@ async fn test_send_to_only_specific_receiver() {
     loop {
         tokio::select! {
             _ = sending_tick.tick() => {
-                node_1.send_to(address_2, create_sync_req(1));
+                node_1.send_hotstuff_rs_msg(address_2, create_sync_req(1));
 
                 if sending_limit == 0 { break }
                 sending_limit -= 1;
@@ -195,8 +195,8 @@ async fn test_sparse_messaging() {
     loop {
         tokio::select! {
             _ = sending_tick.tick() => {
-                node_1.send_to(address_3, message_to_node3.clone());
-                node_3.send_to(address_1, message_to_node1.clone());
+                node_1.send_hotstuff_rs_msg(address_3, message_to_node3.clone());
+                node_3.send_hotstuff_rs_msg(address_1, message_to_node1.clone());
 
                 if sending_limit == 0 { break }
                 sending_limit -= 1;
@@ -233,7 +233,7 @@ async fn test_send_to_self() {
         tokio::select! {
             //broadcast does not send to self
             _ = sending_tick.tick() => {
-                node_1.send_to(address_1, message.clone());
+                node_1.send_hotstuff_rs_msg(address_1, message.clone());
                 if sending_limit == 0 { break }
                 sending_limit -= 1;
             }
@@ -261,7 +261,7 @@ async fn test_broadcast_different_topics() {
         30015,
         vec![PeerInfo::new(address_1, Ipv4Addr::new(127, 0, 0, 1), 30014)],
         Some(Topic::Mempool),
-        vec![Topic::Consensus],
+        vec![Topic::HotStuffRsBroadcast],
     )
     .await;
 
@@ -272,7 +272,7 @@ async fn test_broadcast_different_topics() {
     loop {
         tokio::select! {
             _ = sending_tick.tick() => {
-                node_1.broadcast_mempool_tx_msg(&base_tx(address_1));
+                node_1.broadcast_mempool_msg(&base_tx(address_1));
                 if sending_limit == 0 { break }
                 sending_limit -= 1;
             }
@@ -307,7 +307,7 @@ pub async fn node(
     let gate = if !subscribe_topics.is_empty() {
         MessageCounts::new(gate_topic.unwrap())
     } else {
-        MessageCounts::new(Topic::Mailbox(address))
+        MessageCounts::new(Topic::HotStuffRsSend(address))
     };
     let message_chain = MessageGateChain::new().append(gate.clone());
 

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -6,7 +6,7 @@ use futures::lock::Mutex;
 use hotstuff_rs::messages::SyncRequest;
 use libp2p::{identity::{Keypair, PublicKey}, gossipsub::TopicHash};
 use pchain_network::{
-    config::{Config, Peer},
+    config::{Config, PeerInfo},
     message_gate::{MessageGate, MessageGateChain},
     messages::{Topic, Envelope, Message},
     NetworkHandle,
@@ -42,7 +42,7 @@ async fn test_broadcast() {
     let (address_1, node_1, _) = node(30001, vec![], None, vec![]).await;
     let (_address_2, _node_2, receiver_gate) = node(
         30002,
-        vec![Peer::new(address_1, Ipv4Addr::new(127, 0, 0, 1), 30001)],
+        vec![PeerInfo::new(address_1, Ipv4Addr::new(127, 0, 0, 1), 30001)],
         Some(Topic::Mempool),
         vec![Topic::Mempool],
     )
@@ -82,7 +82,7 @@ async fn test_send_to() {
 
     let (address_2, _node_2, receiver_gate) = node(
         30004,
-        vec![Peer::new(address_1, Ipv4Addr::new(127, 0, 0, 1), 30003)],
+        vec![PeerInfo::new(address_1, Ipv4Addr::new(127, 0, 0, 1), 30003)],
         None,
         vec![],
     )
@@ -124,7 +124,7 @@ async fn test_send_to_only_specific_receiver() {
 
     let (address_2, _node_2, _) = node(
         30006,
-        vec![Peer::new(address_1, Ipv4Addr::new(127, 0, 0, 1), 30005)],
+        vec![PeerInfo::new(address_1, Ipv4Addr::new(127, 0, 0, 1), 30005)],
         None,
         vec![],
     )
@@ -132,7 +132,7 @@ async fn test_send_to_only_specific_receiver() {
 
     let (_address_3, _node_3, receiver_gate) = node(
         30007,
-        vec![Peer::new(address_1, Ipv4Addr::new(127, 0, 0, 1), 30005)],
+        vec![PeerInfo::new(address_1, Ipv4Addr::new(127, 0, 0, 1), 30005)],
         None,
         vec![],
     )
@@ -171,7 +171,7 @@ async fn test_sparse_messaging() {
 
     let (address_2, _node_2, _) = node(
         30009,
-        vec![Peer::new(address_1, Ipv4Addr::new(127, 0, 0, 1), 30008)],
+        vec![PeerInfo::new(address_1, Ipv4Addr::new(127, 0, 0, 1), 30008)],
         None,
         vec![],
     )
@@ -179,7 +179,7 @@ async fn test_sparse_messaging() {
 
     let (address_3, node_3, receiver_gate_3) = node(
         30010,
-        vec![Peer::new(address_2, Ipv4Addr::new(127, 0, 0, 1), 30009)],
+        vec![PeerInfo::new(address_2, Ipv4Addr::new(127, 0, 0, 1), 30009)],
         None,
         vec![],
     )
@@ -259,7 +259,7 @@ async fn test_broadcast_different_topics() {
 
     let (_address_2, _node_2, receiver_gate) = node(
         30015,
-        vec![Peer::new(address_1, Ipv4Addr::new(127, 0, 0, 1), 30014)],
+        vec![PeerInfo::new(address_1, Ipv4Addr::new(127, 0, 0, 1), 30014)],
         Some(Topic::Mempool),
         vec![Topic::Consensus],
     )
@@ -287,7 +287,7 @@ async fn test_broadcast_different_topics() {
 
 pub async fn node(
     port: u16,
-    boot_nodes: Vec<Peer>,
+    boot_nodes: Vec<PeerInfo>,
     gate_topic: Option<Topic>,
     subscribe_topics: Vec<Topic>,
 ) -> (PublicAddress, NetworkHandle, MessageCounts) {


### PR DESCRIPTION
#### Requirements

1. Edit item docs and internal comments to be more informative and contain the latest information. 

2. Refactor ambiguous relationship between the engine and network_handle modules. Specifically, adding engine thread JoinHandle<()> to allow a graceful shutdown of the network and implementing a more intuitive NetworkHandle via [Peer] struct. 

````
    struct Peer {
        engine: JoinHandle<()>,
        to_engine: Sender<EngineCommand>,
    }

    impl Peer {
        pub fn broadcast_mempool_msg(&self, txn: TransactionV1ToV2);
        pub fn broadcast_hotstuff_rs_msg(&self, msg: hotstuff_rs::Message);
        pub fn broadcast_dropped_txn_msg(&self, msg: DroppedTxnMessage);
        pub fn send_hotstuff_rs_msg(&self, msg: hotstuff_rs::Message);
   } 
````

3. Removing “Send To” and “Broadcast” semantics in the codebase, instead a topic-oriented semantics is preferred (one topic for HotStuff-rs, one topic for Mempool).

4. Implementation of EngineCommand 

````
    enum EngineCommand {
        Publish(Topic, Message),
        Shutdown,
    }
````

5. Rename topics as shown to make relationship between Consensus and Mailbox topics more explicit. 

````
    pub enum Topic {
        HotStuffRsBroadcast,
        HotStuffRsSend(PeerID),
        Mempool,
        DroppedTxns,
    }
````

6. The concrete type of the error type of engine::start should be present instead of using Box<dyn Error>. 

7. Consistent Logging, detail and text formatting.

8. Consistent “use” statements