### PR TITLE
WIP: Refactor pchain network engine 

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,6 @@ pub(crate) struct Config {
     pub kademlia_protocol_names: Vec<String>,
 }
 
-fn fullnode_topics(public_address: PublicAddress) -> Vec<Topic> {
+pub(crate) fn fullnode_topics(public_address: PublicAddress) -> Vec<Topic> {
     vec![Topic::HotStuffRsBroadcast, Topic::HotStuffRsSend(public_address).into(), Topic::Mempool, Topic::DroppedTxns]
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@ pub(crate) struct Config {
     pub outgoing_msgs_buffer_capacity: usize,
     pub incoming_msgs_buffer_capacity: usize,
     pub peer_discovery_interval: u64,
-    pub kademlia_protocol_names: Vec<String>,
+    pub protocol_name: String,
 }
 
 pub(crate) fn fullnode_topics(public_address: PublicAddress) -> Vec<Topic> {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -42,11 +42,10 @@ use std::time::Duration;
 use crate::{
     behaviour::{Behaviour, PeerNetworkEvent},
     config,
-    messages::{Envelope, Topic, DroppedTxMessage},
-    peer::{EngineCommand, PeerBuilder, Peer}, conversions,
+    conversions,
+    messages::{DroppedTxMessage, Envelope, Topic},
+    peer::{EngineCommand, PeerBuilder, Peer},
 };
-
-const KADEMLIA_PROTOCOL_NAME: &str = "/pchain_p2p/1.0.0";
 
 /// [start] p2p networking peer and return the handle [NetworkHandle] of this process.
 pub(crate) async fn start(
@@ -71,9 +70,7 @@ pub(crate) async fn start(
     let transport = build_transport(local_keypair.clone()).await?;
     let behaviour = Behaviour::new(
         local_public_address,
-        &local_keypair,
-        10,
-        &config.kademlia_protocol_names, //TODO jonas
+        &local_keypair
     );
     
     let mut swarm = SwarmBuilder::with_tokio_executor(transport, behaviour, local_peer_id).build();
@@ -90,7 +87,6 @@ pub(crate) async fn start(
     }
 
     // 3. Subscribe to Topic
-    //TODO jonas
     swarm.behaviour_mut().subscribe(config::fullnode_topics(local_public_address))?;
 
     // 4. Start p2p networking

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -40,6 +40,7 @@ use std::time::Duration;
 
 use crate::{
     behaviour::{Behaviour, PeerNetworkEvent},
+    config,
     messages::{Envelope, Topic},
     peer::{EngineCommand, PeerBuilder, Peer}, conversions,
 };
@@ -89,7 +90,7 @@ pub(crate) async fn start(
 
     // 3. Subscribe to Topic
     //TODO jonas
-    swarm.behaviour_mut().subscribe()?;
+    swarm.behaviour_mut().subscribe(config::fullnode_topics(local_public_address))?;
 
     // 4. Start p2p networking
     let (sender, mut receiver) =

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -6,7 +6,7 @@ use pchain_types::{blockchain::TransactionV1, cryptography::{Sha256Hash, PublicA
 /// Hash of the message topic.
 pub type MessageTopicHash = libp2p::gossipsub::TopicHash;
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum Topic {
     HotStuffRsBroadcast,
     HotStuffRsSend(PublicAddress),


### PR DESCRIPTION
### Changes 
1. network subscribes to `Vec<Topic>` from `config::fullnode_topics(local_public_address)` instead of being a separate argument to `start`
2. Message types are determined via `message.topic.as_str()` which can be matched to: "consensus", "mempool" , "droppedTx" and public address string. The message data can then be deserialised  according to the type of message it is: 
    - `hotstuff_rs::messages::Message`
    - `pchain_types::blockchain::TransactionV1`
    - `DroppedTxMessage`
    
3. constant inputs like protocol name and heartbeat seconds were being passed as arguments to `Behaviour::new()` which were subsequently passed as arguments to `kad_config()` and `gossipsub_config`. Removed these redundant arguments and used them in the lowest level functions instead. 